### PR TITLE
Fixing a bug that causes an exception to be thrown after making any edits to a designer file in Visual Studio.

### DIFF
--- a/Aga.Controls/Tree/TreeViewAdv.Properties.cs
+++ b/Aga.Controls/Tree/TreeViewAdv.Properties.cs
@@ -64,7 +64,7 @@ namespace Aga.Controls.Tree
 			}
 			set
 			{
-				if (value <= 0)
+				if (value < 0)
 					throw new ArgumentOutOfRangeException("value");
 				_headerLayout.PreferredHeaderHeight = value;
 				FullUpdate();


### PR DESCRIPTION
The exception in this conditional was being thrown every time a designer file containing a TreeViewAdv (with no columns) was modified in Visual Studio. Visual Studio would call the getter for this property, and if UseColumns is false, Visual Studio would fill the property with 0.

``` C#
#region Windows Form Designer generated code
...
///
/// treeViewAdv
///
...
this.treeViewAdv.ColumnHeaderHeight = 0;
...
# endregion
```

 When running the application, the ArgumentOutOfRangeException would be thrown. The only solution is to comment out the Visual Studio-generated line of code code every time you make a change in the editor- quite infuriating! When running the application after commenting out this line, the property is 0 anyways. (since UseColumns is false) 

I've spent the morning browsing through this library and I don't anticipate any potential bugs arising out of this change, but I would consider myself far from an expert in regards to the full featureset of this library. An alternative change would be to change the condition to "(value <= 0 && UseColumns)" if 0 is truly an invalid value for a header height.
