### PR TITLE
Implement EditableControl.Shown event

### DIFF
--- a/Aga.Controls/Tree/NodeControls/EditableControl.cs
+++ b/Aga.Controls/Tree/NodeControls/EditableControl.cs
@@ -71,6 +71,7 @@ namespace Aga.Controls.Tree.NodeControls
 				{
 					var editor = CreateEditor(Parent.CurrentNode);
 					Parent.DisplayEditor(editor, this);
+					OnEditorShown();
 				}
 			}
 		}
@@ -175,6 +176,11 @@ namespace Aga.Controls.Tree.NodeControls
 		{
 			if (ChangesApplied != null)
 				ChangesApplied(this, EventArgs.Empty);
+		}
+		
+		public event EventHandler EditorShown;
+		protected void OnEditorShown(){
+			EditorShown?.Invoke(this,EventArgs.Empty)
 		}
 
 		#endregion


### PR DESCRIPTION
Raise an event when the control is shown and the location is known. So you can subscribe to this event to display information controls next to the editor. I needed this event when working with the ribbon framework to display a mini toolbar next to the editor.
